### PR TITLE
HAS_HIDPI_FIX field

### DIFF
--- a/lwjgl/src/main/java/org/lwjgl/Sys.java
+++ b/lwjgl/src/main/java/org/lwjgl/Sys.java
@@ -60,6 +60,8 @@ public final class Sys {
 	private static final SysImplementation implementation;
 	private static final boolean is64Bit;
 
+	public static final boolean HAS_HIDPI_FIX = true;
+
 	private static void doLoadLibrary(final String lib_name) {
 		AccessController.doPrivileged(new PrivilegedAction<Object>() {
 			public Object run() {


### PR DESCRIPTION
Currently, there is no reliable way of checking if a LWJGL native contains the HiDPI fix recently merged without initializing LWJGL itself; `getImplementationVersion()` is unreliable, and calling `Sys.getVersion` will call its static constructor (which loads the LWJGL natives). Hence, this variable exists so mods can detect the fix via reflection.